### PR TITLE
MAMBA F405_US voltage/current scale

### DIFF
--- a/src/main/target/MAMBAF405US/config.c
+++ b/src/main/target/MAMBAF405US/config.c
@@ -48,6 +48,10 @@
 #include "io/piniobox.h"
 
 void targetConfiguration(void)
+    
+    batteryMetersConfigMutable()->voltage.scale = 1100;
+    batteryMetersConfigMutable()->current.scale = 183;
+
 {
 #ifdef MAMBAF405US
     // MSP @ 19200 on SERIAL4


### PR DESCRIPTION
set voltage/current sensor scalings

Voltage scale devised from testing
Current scale devised from documentation

See:
https://cdn.shopify.com/s/files/1/0027/2708/4144/files/3-MAMBA_Basic_F405_MINI_MK3.5.pdf